### PR TITLE
style: improve quote card rounded corner for dark mode

### DIFF
--- a/src/components/QuoteCard.vue
+++ b/src/components/QuoteCard.vue
@@ -22,7 +22,7 @@ function getGradientByIndex (index: number = 0) {
 
 <template>
   <div class="w-full relative text-white overflow-hidden flex rounded-3xl shadow-lg md:hover:rotate-1 duration-300 p-2" :class="((size === 'lg') ? 'scale-1 md:scale-150 md:hover:scale-160' : 'md:hover:scale-105') + ' ' + getGradientByIndex(quote.gradient_id)">
-    <div class="w-full flex flex-col dark:bg-gray-800 dark:rounded-3xl">
+    <div class="w-full flex flex-col dark:bg-gray-800 dark:rounded-2.2xl">
       <div class="sm:max-w-sm sm:flex-none md:w-auto flex flex-col items-start relative p-6 xl:p-8">
         <h2 class="text-xl font-semibold mb-2">
           <i-ri-double-quotes-l />

--- a/src/components/QuoteGallery.vue
+++ b/src/components/QuoteGallery.vue
@@ -80,7 +80,7 @@ onUnmounted(function () {
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5 md:gap-6 xl:gap-8">
         <section class="flex">
           <div class="w-full relative text-white overflow-hidden rounded-3xl flex shadow-lg p-2 bg-gradient-to-br from-red-100 to-blue-100">
-            <div class="w-full flex flex-col dark:bg-gray-800 dark:rounded-3xl">
+            <div class="w-full flex flex-col dark:bg-gray-800 dark:rounded-2.2xl">
               <div class="sm:max-w-sm sm:flex-none md:w-auto flex flex-col items-start relative p-6 xl:p-8">
                 <h1 class="mb-2 text-gray-800 dark:text-red-100">
                   <i-ri-chat-quote-line class="text-3xl" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,11 @@ module.exports = {
   ],
   darkMode: 'class', // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      borderRadius: {
+        '2.2xl': '18px'
+      }
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
It is a small detail fix for the quote card style, that comes when dark mode enabled. The inside corner radius of the card not matching with its outside, so it is showed weird.

Here is the screenshots of the changes:

Before:
![Before](https://user-images.githubusercontent.com/11625690/136130178-cfa51d77-831d-43c1-b8fc-8e8d44ba0b89.png)

After:
![After](https://user-images.githubusercontent.com/11625690/136130195-2bc60d91-aac9-4c11-9899-956b36061970.png)
