### PR TITLE
Fix search corner radius problem on iOS

### DIFF
--- a/src/components/QuoteSearch.vue
+++ b/src/components/QuoteSearch.vue
@@ -85,6 +85,6 @@ debouncedWatch(search, () => {
   @apply text-[11px] leading-[20px] py-0 px-[7px] inline-flex items-center mr-2 md:mr-3 rounded-xl ring-1 text-purple-800 dark:text-purple-400 ring-purple-300 bg-[#e0daf8] dark:bg-[#1c2332];
 }
 .search-main--input {
-  @apply pl-9 pr-4 py-2 border border-l-0 bg-gray-100 focus:bg-gray-50 border-gray-300 text-sm rounded-r-md w-full transition appearance-none outline-none dark:bg-gray-900 dark:text-gray-100 dark:border-gray-500;
+  @apply pl-9 pr-4 py-2 border border-l-0 bg-gray-100 focus:bg-gray-50 border-gray-300 text-sm rounded-l-none rounded-r-md w-full transition appearance-none outline-none dark:bg-gray-900 dark:text-gray-100 dark:border-gray-500;
 }
 </style>


### PR DESCRIPTION
This problem appear on iOS only (as I was checked), tried both on Safari & Chrome with the same result. The problem is, the border radius also applied for the left side (see image below).

And I found that the problem comes from the default User Agent style.

Problem:
![Problem](https://user-images.githubusercontent.com/11625690/137589508-56920842-d530-4576-98b8-ca4ce8a92aca.PNG)

Solution:

![Solution](https://user-images.githubusercontent.com/11625690/137589516-a5166780-6c60-4aff-b99d-a5f7f5b19dd5.PNG)

And here is the User Agent style that I was mentioned above.

![User Agent Style](https://user-images.githubusercontent.com/11625690/137589565-00c74e31-6f67-463c-a471-6834b3183658.png)
