### PR TITLE
Prevent show quote dialog when click on github profile

### DIFF
--- a/src/components/QuoteCard.vue
+++ b/src/components/QuoteCard.vue
@@ -68,7 +68,7 @@ function getGradientByIndex(index = 0) {
 
           <div class="flex flex-col flex-1">
             <div>
-              <a class="text-xs" :href="`https://github.com/${quote.username}`" nofollow="true" target="_blank" rel="noopener">{{ quote.github?.name }}</a>
+              <a class="text-xs" :href="`https://github.com/${quote.username}`" nofollow="true" target="_blank" rel="noopener" @click.stop>{{ quote.github?.name }}</a>
             </div>
 
             <div class="flex items-center">


### PR DESCRIPTION
Hi @nyancodeid , I think there is no need to show up quote dialog when we click on github profile